### PR TITLE
API稼働レポートをクライアント表示順でソート

### DIFF
--- a/src/Service/ApiReportService.php
+++ b/src/Service/ApiReportService.php
@@ -25,8 +25,9 @@ final class ApiReportService
             ->where('te.date BETWEEN :date_from AND :date_to')
             ->setParameter('date_from', $this->parseDate($dateFrom))
             ->setParameter('date_to', $this->parseDate($dateTo))
-            ->groupBy('c.id, c.name')
-            ->orderBy('c.name', 'ASC')
+            ->groupBy('c.id, c.name, c.sortOrder')
+            ->orderBy('c.sortOrder', 'ASC')
+            ->addOrderBy('c.name', 'ASC')
             ->getQuery()
             ->getArrayResult();
 

--- a/tests/Service/ApiReportServiceTest.php
+++ b/tests/Service/ApiReportServiceTest.php
@@ -45,6 +45,7 @@ final class ApiReportServiceTest extends TestCase
         );
         $queryBuilder->method('groupBy')->willReturnSelf();
         $queryBuilder->method('orderBy')->willReturnSelf();
+        $queryBuilder->method('addOrderBy')->willReturnSelf();
         $queryBuilder->method('getQuery')->willReturn($query);
 
         $entityManager = $this->createMock(EntityManagerInterface::class);


### PR DESCRIPTION
## 概要
- `summarizeHoursByClient` の並び順をクライアント表示順に変更
- 同一表示順の場合はクライアント名で安定ソート
- テストの QueryBuilder モックに `addOrderBy` を追加

## 変更ファイル
- `src/Service/ApiReportService.php`
- `tests/Service/ApiReportServiceTest.php`

## 動作確認
- `mise x php@8.4 -- composer test -- tests/Service/ApiReportServiceTest.php`
  - テストは成功
  - `var/cache/phpunit/test-results` への書き込み権限警告あり
