### PR TITLE
ダッシュボードに今週の稼働時間を追加

### DIFF
--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -33,11 +33,29 @@ final class HomeController
         $monthKeys = array_map(static fn (DateTimeInterface $month): string => $month->format('Y-m'), $months);
         $rowsByClient = $this->buildClientRows($clientSummaries, $monthKeys);
         $columnTotals = $this->buildColumnTotals($totalSummaries, $monthKeys);
+        $weekDates = $this->buildCurrentWeekDates();
+        $weekRange = $this->buildDateRangeForDates($weekDates);
+        $weeklyClientSummaries = $this->timeEntrySummaryService->summarizeHoursByClientByDate(
+            $weekRange['from'],
+            $weekRange['to'],
+        );
+        $weeklyTotalSummaries = $this->timeEntrySummaryService->summarizeTotalHoursByDate(
+            $weekRange['from'],
+            $weekRange['to'],
+        );
+        $weekDateKeys = array_map(static fn (DateTimeInterface $date): string => $date->format('Y-m-d'), $weekDates);
+        $weeklyClientRows = $this->buildWeeklyClientRows($weeklyClientSummaries, $weekDateKeys);
+        $weeklyColumnTotals = $this->buildWeeklyColumnTotals($weeklyTotalSummaries, $weekDateKeys);
+        $weeklyGrandTotal = round(array_sum($weeklyColumnTotals), 2);
 
         return Twig::fromRequest($request)->render($response, 'dashboard.html.twig', [
             'months' => $this->formatMonths($months),
             'clientRows' => array_values($rowsByClient),
             'columnTotals' => $columnTotals,
+            'weekDates' => $this->formatWeekDates($weekDates),
+            'weeklyClientRows' => $weeklyClientRows,
+            'weeklyColumnTotals' => $weeklyColumnTotals,
+            'weeklyGrandTotal' => $weeklyGrandTotal,
         ]);
     }
 
@@ -59,6 +77,14 @@ final class HomeController
         return [
             'from' => $oldestMonth->format('Y-m-01'),
             'to' => $months[0]->format('Y-m-t'),
+        ];
+    }
+
+    private function buildDateRangeForDates(array $dates): array
+    {
+        return [
+            'from' => $dates[0]->format('Y-m-d'),
+            'to' => $dates[array_key_last($dates)]->format('Y-m-d'),
         ];
     }
 
@@ -129,5 +155,106 @@ final class HomeController
             ],
             $months,
         );
+    }
+
+    private function buildCurrentWeekDates(): array
+    {
+        $dates = [];
+        $start = new DateTimeImmutable('monday this week');
+
+        for ($offset = 0; $offset < 7; $offset++) {
+            $dates[] = $start->modify(sprintf('+%d day', $offset));
+        }
+
+        return $dates;
+    }
+
+    private function buildWeeklyClientRows(array $weeklyClientSummaries, array $weekDateKeys): array
+    {
+        $rowsByClient = [];
+        foreach ($weeklyClientSummaries as $summary) {
+            $dateKey = (string) $summary['date_key'];
+            if (!in_array($dateKey, $weekDateKeys, true)) {
+                continue;
+            }
+
+            $clientId = (int) $summary['client_id'];
+            if (!isset($rowsByClient[$clientId])) {
+                $rowsByClient[$clientId] = [
+                    'client_name' => (string) $summary['client_name'],
+                    'hours_by_date' => [],
+                    'weekly_total_hours' => 0.0,
+                ];
+            }
+
+            $hours = round((float) $summary['total_hours'], 2);
+            $rowsByClient[$clientId]['hours_by_date'][$dateKey] = $hours;
+            $rowsByClient[$clientId]['weekly_total_hours'] += $hours;
+        }
+
+        foreach ($rowsByClient as &$row) {
+            foreach ($weekDateKeys as $dateKey) {
+                $row['hours_by_date'][$dateKey] = round((float) ($row['hours_by_date'][$dateKey] ?? 0.0), 2);
+            }
+            $row['weekly_total_hours'] = round((float) $row['weekly_total_hours'], 2);
+        }
+        unset($row);
+
+        uasort($rowsByClient, static function (array $left, array $right): int {
+            $leftHours = (float) $left['weekly_total_hours'];
+            $rightHours = (float) $right['weekly_total_hours'];
+            if ($leftHours === $rightHours) {
+                return strcmp((string) $left['client_name'], (string) $right['client_name']);
+            }
+
+            return $rightHours <=> $leftHours;
+        });
+
+        return array_values($rowsByClient);
+    }
+
+    private function buildWeeklyColumnTotals(array $weeklyTotalSummaries, array $weekDateKeys): array
+    {
+        $columnTotals = array_fill_keys($weekDateKeys, 0.0);
+        foreach ($weeklyTotalSummaries as $summary) {
+            $dateKey = (string) $summary['date_key'];
+            if (!array_key_exists($dateKey, $columnTotals)) {
+                continue;
+            }
+            $columnTotals[$dateKey] = round((float) $summary['total_hours'], 2);
+        }
+
+        return $columnTotals;
+    }
+
+    private function formatWeekDates(array $weekDates): array
+    {
+        $todayKey = (new DateTimeImmutable('today'))->format('Y-m-d');
+
+        return array_map(static function (DateTimeInterface $date) use ($todayKey): array {
+            $dateKey = $date->format('Y-m-d');
+            $dayOfWeek = (int) $date->format('N');
+
+            return [
+                'key' => $dateKey,
+                'label' => sprintf('%s (%s)', $date->format('n/j'), self::weekdayLabel($date)),
+                'is_today' => $dateKey === $todayKey,
+                'is_saturday' => $dayOfWeek === 6,
+                'is_sunday' => $dayOfWeek === 7,
+            ];
+        }, $weekDates);
+    }
+
+    private static function weekdayLabel(DateTimeInterface $date): string
+    {
+        return match ((int) $date->format('N')) {
+            1 => '月',
+            2 => '火',
+            3 => '水',
+            4 => '木',
+            5 => '金',
+            6 => '土',
+            default => '日',
+        };
     }
 }

--- a/src/Service/TimeEntrySummaryService.php
+++ b/src/Service/TimeEntrySummaryService.php
@@ -96,6 +96,64 @@ final class TimeEntrySummaryService
         ], $rows);
     }
 
+    public function summarizeHoursByClientByDate(string $dateFrom, string $dateTo): array
+    {
+        $queryBuilder = $this->entityManager->getConnection()->createQueryBuilder();
+
+        $rows = $queryBuilder
+            ->select(
+                'c.id AS client_id',
+                'c.name AS client_name',
+                'te.date AS date_key',
+                'SUM(te.hours) AS total_hours',
+            )
+            ->from('time_entries', 'te')
+            ->innerJoin('te', 'clients', 'c', 'c.id = te.client_id')
+            ->where('te.date BETWEEN :date_from AND :date_to')
+            ->setParameter('date_from', $dateFrom)
+            ->setParameter('date_to', $dateTo)
+            ->groupBy('c.id')
+            ->addGroupBy('c.name')
+            ->addGroupBy('c.sort_order')
+            ->addGroupBy('date_key')
+            ->orderBy('c.sort_order', 'ASC')
+            ->addOrderBy('c.name', 'ASC')
+            ->addOrderBy('date_key', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_map(static fn (array $row): array => [
+            'client_id' => (int) $row['client_id'],
+            'client_name' => (string) $row['client_name'],
+            'date_key' => (string) $row['date_key'],
+            'total_hours' => (float) $row['total_hours'],
+        ], $rows);
+    }
+
+    public function summarizeTotalHoursByDate(string $dateFrom, string $dateTo): array
+    {
+        $queryBuilder = $this->entityManager->getConnection()->createQueryBuilder();
+
+        $rows = $queryBuilder
+            ->select(
+                'te.date AS work_date',
+                'SUM(te.hours) AS total_hours',
+            )
+            ->from('time_entries', 'te')
+            ->where('te.date BETWEEN :date_from AND :date_to')
+            ->setParameter('date_from', $dateFrom)
+            ->setParameter('date_to', $dateTo)
+            ->groupBy('work_date')
+            ->orderBy('work_date', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_map(static fn (array $row): array => [
+            'date_key' => (string) $row['work_date'],
+            'total_hours' => (float) $row['total_hours'],
+        ], $rows);
+    }
+
     private function parseDate(string $date): DateTimeImmutable
     {
         $parsed = DateTimeImmutable::createFromFormat('!Y-m-d', $date);

--- a/templates/dashboard.html.twig
+++ b/templates/dashboard.html.twig
@@ -5,7 +5,42 @@
 {% block body %}
     <h1>Kizami</h1>
 
-    <h2>クライアント別稼働時間</h2>
+    <h2>今週の稼働時間</h2>
+    <div class="table-wrap">
+        <table>
+            <thead>
+            <tr>
+                <th>クライアント</th>
+                {% for weekDate in weekDates %}
+                    <th class="number-cell{% if weekDate.is_today %} week-col-today{% endif %}{% if weekDate.is_saturday %} week-text-saturday{% endif %}{% if weekDate.is_sunday %} week-text-sunday{% endif %}">
+                        {{ weekDate.label }}
+                    </th>
+                {% endfor %}
+                <th class="number-cell">週合計 (h)</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for row in weeklyClientRows %}
+                <tr>
+                    <td>{{ row.client_name }}</td>
+                    {% for weekDate in weekDates %}
+                        <td class="number-cell{% if weekDate.is_today %} week-col-today{% endif %}">{{ row.hours_by_date[weekDate.key]|number_format(2, '.', '') }}</td>
+                    {% endfor %}
+                    <td class="number-cell"><strong>{{ row.weekly_total_hours|number_format(2, '.', '') }}</strong></td>
+                </tr>
+            {% endfor %}
+            <tr>
+                <td><strong>合計</strong></td>
+                {% for weekDate in weekDates %}
+                    <td class="number-cell{% if weekDate.is_today %} week-col-today{% endif %}"><strong>{{ weeklyColumnTotals[weekDate.key]|number_format(2, '.', '') }}</strong></td>
+                {% endfor %}
+                <td class="number-cell"><strong>{{ weeklyGrandTotal|number_format(2, '.', '') }}</strong></td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <h2>直近{{ months|length }}ヶ月の稼働時間</h2>
     {% if clientRows %}
         <div class="table-wrap">
             <table>
@@ -38,4 +73,5 @@
     {% else %}
         <p>直近4ヶ月の稼働時間はまだありません。</p>
     {% endif %}
+
 {% endblock %}

--- a/templates/layout/base.html.twig
+++ b/templates/layout/base.html.twig
@@ -147,6 +147,20 @@
             font-variant-numeric: tabular-nums;
         }
 
+        .week-col-today {
+            background: rgba(148, 163, 184, 0.28);
+            box-shadow: inset 0 1px 0 rgba(203, 213, 225, 0.28), inset 0 -1px 0 rgba(203, 213, 225, 0.22);
+            font-weight: 600;
+        }
+
+        .week-text-saturday {
+            color: #60a5fa;
+        }
+
+        .week-text-sunday {
+            color: #f87171;
+        }
+
         .comment-cell {
             white-space: pre-wrap;
             word-break: break-word;

--- a/tests/Service/TimeEntrySummaryServiceTest.php
+++ b/tests/Service/TimeEntrySummaryServiceTest.php
@@ -188,4 +188,119 @@ final class TimeEntrySummaryServiceTest extends TestCase
             ],
         ], $rows);
     }
+
+    #[Test]
+    public function summarizeHoursByClientByDateShouldUseSingleQueryBuilderQuery(): void
+    {
+        $result = $this->createMock(Result::class);
+        $result->expects(self::once())
+            ->method('fetchAllAssociative')
+            ->willReturn([
+                [
+                    'client_id' => 1,
+                    'client_name' => 'Acme',
+                    'date_key' => '2026-02-23',
+                    'total_hours' => '3.50',
+                ],
+                [
+                    'client_id' => 1,
+                    'client_name' => 'Acme',
+                    'date_key' => '2026-02-24',
+                    'total_hours' => '4.25',
+                ],
+            ]);
+
+        $queryBuilder = $this->createMock(DbalQueryBuilder::class);
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('innerJoin')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder->method('setParameter')->willReturnSelf();
+        $queryBuilder->method('groupBy')->willReturnSelf();
+        $queryBuilder->method('addGroupBy')->willReturnSelf();
+        $queryBuilder->method('orderBy')->willReturnSelf();
+        $queryBuilder->method('addOrderBy')->willReturnSelf();
+        $queryBuilder->expects(self::once())
+            ->method('executeQuery')
+            ->willReturn($result);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::once())
+            ->method('createQueryBuilder')
+            ->willReturn($queryBuilder);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getConnection')->willReturn($connection);
+
+        $service = new TimeEntrySummaryService($entityManager);
+
+        $rows = $service->summarizeHoursByClientByDate('2026-02-23', '2026-03-01');
+
+        self::assertSame([
+            [
+                'client_id' => 1,
+                'client_name' => 'Acme',
+                'date_key' => '2026-02-23',
+                'total_hours' => 3.5,
+            ],
+            [
+                'client_id' => 1,
+                'client_name' => 'Acme',
+                'date_key' => '2026-02-24',
+                'total_hours' => 4.25,
+            ],
+        ], $rows);
+    }
+
+    #[Test]
+    public function summarizeTotalHoursByDateShouldUseSingleQueryBuilderQuery(): void
+    {
+        $result = $this->createMock(Result::class);
+        $result->expects(self::once())
+            ->method('fetchAllAssociative')
+            ->willReturn([
+                [
+                    'work_date' => '2026-02-23',
+                    'total_hours' => '7.00',
+                ],
+                [
+                    'work_date' => '2026-02-24',
+                    'total_hours' => '4.25',
+                ],
+            ]);
+
+        $queryBuilder = $this->createMock(DbalQueryBuilder::class);
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder->method('setParameter')->willReturnSelf();
+        $queryBuilder->method('groupBy')->willReturnSelf();
+        $queryBuilder->method('orderBy')->willReturnSelf();
+        $queryBuilder->expects(self::once())
+            ->method('executeQuery')
+            ->willReturn($result);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::once())
+            ->method('createQueryBuilder')
+            ->willReturn($queryBuilder);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getConnection')->willReturn($connection);
+
+        $service = new TimeEntrySummaryService($entityManager);
+
+        $rows = $service->summarizeTotalHoursByDate('2026-02-23', '2026-03-01');
+
+        self::assertSame([
+            [
+                'date_key' => '2026-02-23',
+                'total_hours' => 7.0,
+            ],
+            [
+                'date_key' => '2026-02-24',
+                'total_hours' => 4.25,
+            ],
+        ], $rows);
+    }
 }


### PR DESCRIPTION
### 概要

- ダッシュボードで最初に確認できるよう、今週の稼働時間（月〜日）を追加しました。
- 日別のクライアント別稼働時間を表示し、合計行・週合計も確認できます。
- 当日列は背景色、土日の日付ヘッダーは文字色で判別できるようにしました。

### 対応内容

- TimeEntrySummaryService に日別集計メソッドを追加
  - クライアント別日次: summarizeHoursByClientByDate
  - 全体日次: summarizeTotalHoursByDate
- HomeController で今週（月曜始まり7日間）の表示データを構築
- dashboard.html.twig を更新
  - 「今週の稼働時間」を上部に表示
  - 日次クライアント別テーブルを追加
  - 既存の「クライアント別稼働時間」は下部へ移動
- base.html.twig を更新
  - 当日列の背景色
  - 土曜/日曜の日付ヘッダー文字色
- TimeEntrySummaryServiceTest に日次集計メソッドのテストを追加

Closes #22
