### PR TITLE
コメント入力欄の初期高さを5行に拡大

### DIFF
--- a/templates/home.html.twig
+++ b/templates/home.html.twig
@@ -91,7 +91,7 @@
             </select>
 
             <label for="comment">コメント</label>
-            <textarea id="comment" name="comment" rows="3">{{ old.comment }}</textarea>
+            <textarea id="comment" name="comment" rows="5">{{ old.comment }}</textarea>
 
             <div class="action-buttons register-actions">
                 <button type="submit">登録</button>

--- a/templates/time_entry_edit.html.twig
+++ b/templates/time_entry_edit.html.twig
@@ -62,7 +62,7 @@
 
         <div>
             <label for="comment">コメント</label>
-            <textarea id="comment" name="comment" rows="3">{{ entry.comment }}</textarea>
+            <textarea id="comment" name="comment" rows="5">{{ entry.comment }}</textarea>
         </div>
 
         <button type="submit">更新</button>


### PR DESCRIPTION
## 概要
- コメント入力欄の初期表示行数を3行から5行に変更しました
- 入力画面と編集画面の両方に同じ変更を適用しました

## 変更内容
- templates/home.html.twig のコメント欄 rows を 3 から 5 に変更
- templates/time_entry_edit.html.twig のコメント欄 rows を 3 から 5 に変更

Closes #24
