### PR TITLE
デプロイ処理を gotea 方式に合わせて見直し

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,19 +2,26 @@ name: Deploy
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: [CI]
     types: [completed]
+    branches: [main]
+
+concurrency:
+  group: deploy-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     env:
-      TAR_NAME: "kizami_${{ github.run_number }}.tar.gz"
+      PROJECT: "${{ github.event.repository.name }}"
+      TAR_NAME: "${{ github.run_number }}.tar.gz"
+      TAR_REMOTE_PATH: "~/release/tmp/${{ github.event.repository.name }}/deploy/${{ github.run_number }}.tar.gz"
       SHELL_DEST_PATH: "~/deploy_${{ github.run_number }}.sh"
       DEPLOY_TARGET_PATH: ${{ secrets.DEPLOY_TARGET_PATH }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
       - name: Install SSH Key
@@ -24,18 +31,17 @@ jobs:
           name: id_rsa-target
           known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
           config: |
-            Host *
-              StrictHostKeyChecking no
-              UserKnownHostsFile=/dev/null
             Host target
               HostName ${{ secrets.SSH_HOST }}
               User ${{ secrets.SSH_USER }}
               Port ${{ secrets.SSH_PORT }}
+              StrictHostKeyChecking yes
               IdentityFile ~/.ssh/id_rsa-target
       - name: Transfer modules
         run: |
+          ssh target "mkdir -p ~/release/tmp/${PROJECT}/deploy"
           tar czf ~/${TAR_NAME} app/ bin/ config/ migrations/ public/ src/ templates/ composer.json composer.lock
-          scp -r ~/${TAR_NAME} target:~/
+          scp ~/${TAR_NAME} target:${TAR_REMOTE_PATH}
           scp ./scripts/deploy.sh target:${SHELL_DEST_PATH}
       - name: Deploy modules
         run: |
@@ -43,7 +49,7 @@ jobs:
             echo "DEPLOY_TARGET_PATH is not set"
             exit 1
           fi
-          ssh target "${SHELL_DEST_PATH} ${TAR_NAME} kizami '${DEPLOY_TARGET_PATH}' && rm -f ${SHELL_DEST_PATH}"
+          ssh target "${SHELL_DEST_PATH} ${TAR_REMOTE_PATH} ${PROJECT} '${DEPLOY_TARGET_PATH}' && rm -f ${SHELL_DEST_PATH}"
 
   notify:
     if: ${{ always() && needs.deploy.result != 'skipped' }}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,23 +1,30 @@
 #!/bin/bash
 
-set -Eeuo pipefail
+set -euo pipefail
+IFS=$'\n\t'
 
 if [[ $# -ne 3 ]]; then
-  echo "Usage: $0 <tar_name> <project> <target_path>" >&2
+  echo "Usage: $0 <tar_path> <project> <target_path>" >&2
   exit 1
 fi
 
-readonly TAR_NAME="$1"
+readonly TAR_PATH_INPUT="$1"
 readonly PROJECT="$2"
 readonly TARGET_PATH="$3"
-readonly HOME_TAR_PATH="${HOME}/${TAR_NAME}"
 readonly RELEASE_BASE="${HOME}/release"
 readonly WORK_DIR="${RELEASE_BASE}/link/${PROJECT}"
 readonly DEPLOY_SEQ="$(date +'%Y%m%d-%H%M%S')"
 readonly WWW_DIR="${WORK_DIR}/${DEPLOY_SEQ}"
+readonly CURRENT_PATH="${WORK_DIR}/current"
 readonly LOG_DIR="${RELEASE_BASE}/logs/${PROJECT}"
 readonly ENV_FILE_PATH="${RELEASE_BASE}/environment/${PROJECT}/.env"
 readonly KEEP_RELEASES=3
+
+if [[ "${TAR_PATH_INPUT}" = /* ]]; then
+  readonly TAR_PATH="${TAR_PATH_INPUT}"
+else
+  readonly TAR_PATH="${HOME}/${TAR_PATH_INPUT}"
+fi
 
 log() {
   echo "[deploy] $*"
@@ -34,7 +41,10 @@ require_file() {
 cleanup_old_releases() {
   local work_dir="$1"
   local keep="$2"
-  mapfile -t releases < <(find "${work_dir}" -mindepth 1 -maxdepth 1 -type d -printf '%P\n' | sort -r)
+  mapfile -t releases < <(
+    find "${work_dir}" -mindepth 1 -maxdepth 1 -type d \
+      -regextype posix-extended -regex ".*/[0-9]{8}-[0-9]{6}" -printf '%P\n' | sort -r
+  )
   if [[ "${#releases[@]}" -le "${keep}" ]]; then
     return
   fi
@@ -48,13 +58,19 @@ cleanup_old_releases() {
 # ローカルに配置した PHP のエイリアスに設定されたバージョンを利用する
 export PATH="${HOME}/.php:${PATH}"
 
-require_file "${HOME_TAR_PATH}"
+require_file "${TAR_PATH}"
 require_file "${ENV_FILE_PATH}"
 
 mkdir -p "${WWW_DIR}"
 
-log "アーカイブ展開: ${HOME_TAR_PATH}"
-tar xzf "${HOME_TAR_PATH}" -C "${WWW_DIR}"
+cleanup_tar() {
+  log "利用済みアーカイブ削除: ${TAR_PATH}"
+  rm -f "${TAR_PATH}"
+}
+trap cleanup_tar EXIT
+
+log "アーカイブ展開: ${TAR_PATH}"
+tar xzf "${TAR_PATH}" -C "${WWW_DIR}"
 
 log "ログディレクトリ設定: ${LOG_DIR}"
 mkdir -p "${LOG_DIR}"
@@ -67,7 +83,13 @@ ln -sfn "${ENV_FILE_PATH}" "${WWW_DIR}/.env"
 
 log "Composer install"
 cd "${WWW_DIR}"
-composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader
+composer install \
+  --no-dev \
+  --prefer-dist \
+  --no-interaction \
+  --no-progress \
+  --optimize-autoloader \
+  --classmap-authoritative
 
 log "マイグレーション実行"
 php bin/doctrine migrations:migrate -n
@@ -76,12 +98,56 @@ log "キャッシュ初期化"
 mkdir -p "${WWW_DIR}/var/cache" "${WWW_DIR}/var/doctrine"
 rm -rf "${WWW_DIR}/var/cache/"* "${WWW_DIR}/var/doctrine/"*
 
+LINK_PATH="${WWW_DIR}/public"
+PREVIOUS_PATH=""
+SWITCHED=0
+
+if [[ ! -L "${TARGET_PATH}" ]]; then
+  echo "TARGET_PATH がシンボリックリンクではありません: ${TARGET_PATH}" >&2
+  exit 1
+fi
+
+if [[ ! -L "${CURRENT_PATH}" ]]; then
+  current_target="$(readlink -f "${TARGET_PATH}")"
+  if [[ -z "${current_target}" ]]; then
+    echo "CURRENT_PATH の初期化に失敗しました: ${TARGET_PATH}" >&2
+    exit 1
+  fi
+  ln -sfn "${current_target}" "${CURRENT_PATH}"
+fi
+
+target_dest="$(readlink -f "${TARGET_PATH}")"
+expected_dest="$(readlink -f "${CURRENT_PATH}")"
+if [[ "${target_dest}" != "${expected_dest}" ]]; then
+  ln -sfn "${CURRENT_PATH}" "${TARGET_PATH}"
+  target_dest="$(readlink -f "${TARGET_PATH}")"
+fi
+
+if [[ "${target_dest}" != "${expected_dest}" ]]; then
+  echo "TARGET_PATH のリンク先が想定外です: ${TARGET_PATH} -> ${target_dest}" >&2
+  echo "想定: ${TARGET_PATH} -> ${CURRENT_PATH} (${expected_dest})" >&2
+  exit 1
+fi
+
+if [[ -L "${CURRENT_PATH}" ]]; then
+  PREVIOUS_PATH="$(readlink "${CURRENT_PATH}" || true)"
+fi
+
+rollback() {
+  if [[ "${SWITCHED}" -eq 1 && -n "${PREVIOUS_PATH}" ]]; then
+    ln -sfn "${PREVIOUS_PATH}" "${CURRENT_PATH}"
+    log "デプロイ失敗のためリンクをロールバックしました。${CURRENT_PATH} -> ${PREVIOUS_PATH}"
+  fi
+}
+trap rollback ERR
+
 log "公開リンク切り替え"
-ln -snf "${WWW_DIR}/public" "${TARGET_PATH}"
-log "リンクを生成しました。${WWW_DIR}/public -> ${TARGET_PATH}"
+ln -sfn "${LINK_PATH}" "${CURRENT_PATH}"
+SWITCHED=1
+log "リンクを生成しました。${CURRENT_PATH} -> ${LINK_PATH}"
+trap - ERR
+
+ln -sfn "${CURRENT_PATH}" "${TARGET_PATH}"
 
 log "古いリリース削除"
 cleanup_old_releases "${WORK_DIR}" "${KEEP_RELEASES}"
-
-log "利用済みアーカイブ削除: ${HOME_TAR_PATH}"
-rm -f "${HOME_TAR_PATH}"


### PR DESCRIPTION
## 概要
- Deploy ワークフローを main 限定の workflow_run と concurrency 制御に整理
- デプロイアーカイブの転送先を release/tmp 配下に統一
- scripts/deploy.sh を current シンボリックリンク切替方式に変更し、切替失敗時のロールバック処理を追加

## 変更詳細
- .github/workflows/deploy.yml
  - PROJECT と TAR_REMOTE_PATH を導入
  - SSH 設定を StrictHostKeyChecking yes へ変更
  - デプロイ実行時の引数を project 可変に変更
- scripts/deploy.sh
  - tar パスの絶対/相対対応
  - current リンクの初期化・整合性チェック・切替
  - リリース世代管理の対象をタイムスタンプ形式ディレクトリに限定
  - Composer 実行オプションを強化

## 影響範囲
- デプロイ処理（GitHub Actions / サーバー上のリリース切替ロジック）