### PR TITLE
週ごとのダッシュボードサマリを追加

### DIFF
--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -33,6 +33,21 @@ final class HomeController
         $monthKeys = array_map(static fn (DateTimeInterface $month): string => $month->format('Y-m'), $months);
         $rowsByClient = $this->buildClientRows($clientSummaries, $monthKeys);
         $columnTotals = $this->buildColumnTotals($totalSummaries, $monthKeys);
+
+        $weeks = $this->buildRecentWeeks(5);
+        $weekSummaryRange = $this->buildWeekSummaryRange($weeks);
+        $weekSummaryClientSummaries = $this->timeEntrySummaryService->summarizeHoursByClientByWeek(
+            $weekSummaryRange['from'],
+            $weekSummaryRange['to'],
+        );
+        $weekSummaryTotalSummaries = $this->timeEntrySummaryService->summarizeTotalHoursByWeek(
+            $weekSummaryRange['from'],
+            $weekSummaryRange['to'],
+        );
+        $weekKeys = array_map(static fn (DateTimeInterface $week): string => $week->format('Y-m-d'), $weeks);
+        $weekSummaryClientRows = $this->buildWeekSummaryClientRows($weekSummaryClientSummaries, $weekKeys);
+        $weekSummaryColumnTotals = $this->buildWeekSummaryColumnTotals($weekSummaryTotalSummaries, $weekKeys);
+
         $weekDates = $this->buildCurrentWeekDates();
         $weekRange = $this->buildDateRangeForDates($weekDates);
         $weeklyClientSummaries = $this->timeEntrySummaryService->summarizeHoursByClientByDate(
@@ -56,6 +71,9 @@ final class HomeController
             'weeklyClientRows' => $weeklyClientRows,
             'weeklyColumnTotals' => $weeklyColumnTotals,
             'weeklyGrandTotal' => $weeklyGrandTotal,
+            'weekSummaries' => $this->formatWeekSummaries($weeks),
+            'weekSummaryClientRows' => $weekSummaryClientRows,
+            'weekSummaryColumnTotals' => $weekSummaryColumnTotals,
         ]);
     }
 
@@ -85,6 +103,28 @@ final class HomeController
         return [
             'from' => $dates[0]->format('Y-m-d'),
             'to' => $dates[array_key_last($dates)]->format('Y-m-d'),
+        ];
+    }
+
+    private function buildRecentWeeks(int $count): array
+    {
+        $weeks = [];
+        $base = new DateTimeImmutable('monday this week');
+
+        for ($offset = 0; $offset < $count; $offset++) {
+            $weeks[] = $base->modify(sprintf('-%d week', $offset));
+        }
+
+        return $weeks;
+    }
+
+    private function buildWeekSummaryRange(array $weeks): array
+    {
+        $oldestWeek = $weeks[array_key_last($weeks)];
+
+        return [
+            'from' => $oldestWeek->format('Y-m-d'),
+            'to' => $weeks[0]->modify('+6 days')->format('Y-m-d'),
         ];
     }
 
@@ -146,6 +186,63 @@ final class HomeController
         return $columnTotals;
     }
 
+    private function buildWeekSummaryClientRows(array $clientSummaries, array $weekKeys): array
+    {
+        $rowsByClient = [];
+
+        foreach ($clientSummaries as $summary) {
+            $weekKey = (string) $summary['week_key'];
+            if (!in_array($weekKey, $weekKeys, true)) {
+                continue;
+            }
+
+            $clientId = (int) $summary['client_id'];
+            if (!isset($rowsByClient[$clientId])) {
+                $rowsByClient[$clientId] = [
+                    'client_name' => (string) $summary['client_name'],
+                    'hours_by_week' => [],
+                ];
+            }
+
+            $rowsByClient[$clientId]['hours_by_week'][$weekKey] = (float) $summary['total_hours'];
+        }
+
+        foreach ($rowsByClient as &$row) {
+            foreach ($weekKeys as $weekKey) {
+                $row['hours_by_week'][$weekKey] = round((float) ($row['hours_by_week'][$weekKey] ?? 0.0), 2);
+            }
+        }
+        unset($row);
+
+        $currentWeekKey = $weekKeys[0];
+        uasort($rowsByClient, static function (array $left, array $right) use ($currentWeekKey): int {
+            $leftHours = (float) ($left['hours_by_week'][$currentWeekKey] ?? 0.0);
+            $rightHours = (float) ($right['hours_by_week'][$currentWeekKey] ?? 0.0);
+
+            if ($leftHours === $rightHours) {
+                return strcmp((string) $left['client_name'], (string) $right['client_name']);
+            }
+
+            return $rightHours <=> $leftHours;
+        });
+
+        return array_values($rowsByClient);
+    }
+
+    private function buildWeekSummaryColumnTotals(array $totalSummaries, array $weekKeys): array
+    {
+        $columnTotals = array_fill_keys($weekKeys, 0.0);
+        foreach ($totalSummaries as $summary) {
+            $weekKey = (string) $summary['week_key'];
+            if (!array_key_exists($weekKey, $columnTotals)) {
+                continue;
+            }
+            $columnTotals[$weekKey] = round((float) $summary['total_hours'], 2);
+        }
+
+        return $columnTotals;
+    }
+
     private function formatMonths(array $months): array
     {
         return array_map(
@@ -154,6 +251,17 @@ final class HomeController
                 'label' => $month->format('Y年n月'),
             ],
             $months,
+        );
+    }
+
+    private function formatWeekSummaries(array $weeks): array
+    {
+        return array_map(
+            static fn (DateTimeInterface $week): array => [
+                'key' => $week->format('Y-m-d'),
+                'label' => sprintf('%s - %s', $week->format('n/j'), $week->modify('+6 days')->format('n/j')),
+            ],
+            $weeks,
         );
     }
 

--- a/src/Service/TimeEntrySummaryService.php
+++ b/src/Service/TimeEntrySummaryService.php
@@ -96,6 +96,64 @@ final class TimeEntrySummaryService
         ], $rows);
     }
 
+    public function summarizeHoursByClientByWeek(string $dateFrom, string $dateTo): array
+    {
+        $queryBuilder = $this->entityManager->getConnection()->createQueryBuilder();
+
+        $rows = $queryBuilder
+            ->select(
+                'c.id AS client_id',
+                'c.name AS client_name',
+                'DATE_SUB(te.date, INTERVAL WEEKDAY(te.date) DAY) AS week_start',
+                'SUM(te.hours) AS total_hours',
+            )
+            ->from('time_entries', 'te')
+            ->innerJoin('te', 'clients', 'c', 'c.id = te.client_id')
+            ->where('te.date BETWEEN :date_from AND :date_to')
+            ->setParameter('date_from', $dateFrom)
+            ->setParameter('date_to', $dateTo)
+            ->groupBy('c.id')
+            ->addGroupBy('c.name')
+            ->addGroupBy('c.sort_order')
+            ->addGroupBy('week_start')
+            ->orderBy('c.sort_order', 'ASC')
+            ->addOrderBy('c.name', 'ASC')
+            ->addOrderBy('week_start', 'DESC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_map(static fn (array $row): array => [
+            'client_id' => (int) $row['client_id'],
+            'client_name' => (string) $row['client_name'],
+            'week_key' => (string) $row['week_start'],
+            'total_hours' => (float) $row['total_hours'],
+        ], $rows);
+    }
+
+    public function summarizeTotalHoursByWeek(string $dateFrom, string $dateTo): array
+    {
+        $queryBuilder = $this->entityManager->getConnection()->createQueryBuilder();
+
+        $rows = $queryBuilder
+            ->select(
+                'DATE_SUB(te.date, INTERVAL WEEKDAY(te.date) DAY) AS week_start',
+                'SUM(te.hours) AS total_hours',
+            )
+            ->from('time_entries', 'te')
+            ->where('te.date BETWEEN :date_from AND :date_to')
+            ->setParameter('date_from', $dateFrom)
+            ->setParameter('date_to', $dateTo)
+            ->groupBy('week_start')
+            ->orderBy('week_start', 'DESC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_map(static fn (array $row): array => [
+            'week_key' => (string) $row['week_start'],
+            'total_hours' => (float) $row['total_hours'],
+        ], $rows);
+    }
+
     public function summarizeHoursByClientByDate(string $dateFrom, string $dateTo): array
     {
         $queryBuilder = $this->entityManager->getConnection()->createQueryBuilder();

--- a/templates/dashboard.html.twig
+++ b/templates/dashboard.html.twig
@@ -40,6 +40,40 @@
         </table>
     </div>
 
+    <h2>直近{{ weekSummaries|length }}週の稼働時間</h2>
+    {% if weekSummaryClientRows %}
+        <div class="table-wrap">
+            <table>
+                <thead>
+                <tr>
+                    <th>クライアント</th>
+                    {% for weekSummary in weekSummaries %}
+                        <th class="number-cell">{{ weekSummary.label }} (h)</th>
+                    {% endfor %}
+                </tr>
+                </thead>
+                <tbody>
+                {% for row in weekSummaryClientRows %}
+                    <tr>
+                        <td>{{ row.client_name }}</td>
+                        {% for weekSummary in weekSummaries %}
+                            <td class="number-cell">{{ row.hours_by_week[weekSummary.key]|number_format(2, '.', '') }}</td>
+                        {% endfor %}
+                    </tr>
+                {% endfor %}
+                <tr>
+                    <td><strong>合計</strong></td>
+                    {% for weekSummary in weekSummaries %}
+                        <td class="number-cell"><strong>{{ weekSummaryColumnTotals[weekSummary.key]|number_format(2, '.', '') }}</strong></td>
+                    {% endfor %}
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    {% else %}
+        <p>直近5週の稼働時間はまだありません。</p>
+    {% endif %}
+
     <h2>直近{{ months|length }}ヶ月の稼働時間</h2>
     {% if clientRows %}
         <div class="table-wrap">

--- a/tests/Service/TimeEntrySummaryServiceTest.php
+++ b/tests/Service/TimeEntrySummaryServiceTest.php
@@ -190,6 +190,121 @@ final class TimeEntrySummaryServiceTest extends TestCase
     }
 
     #[Test]
+    public function summarizeHoursByClientByWeekShouldUseSingleQueryBuilderQuery(): void
+    {
+        $result = $this->createMock(Result::class);
+        $result->expects(self::once())
+            ->method('fetchAllAssociative')
+            ->willReturn([
+                [
+                    'client_id' => 1,
+                    'client_name' => 'Acme',
+                    'week_start' => '2026-02-23',
+                    'total_hours' => '18.75',
+                ],
+                [
+                    'client_id' => 1,
+                    'client_name' => 'Acme',
+                    'week_start' => '2026-02-16',
+                    'total_hours' => '12.25',
+                ],
+            ]);
+
+        $queryBuilder = $this->createMock(DbalQueryBuilder::class);
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('innerJoin')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder->method('setParameter')->willReturnSelf();
+        $queryBuilder->method('groupBy')->willReturnSelf();
+        $queryBuilder->method('addGroupBy')->willReturnSelf();
+        $queryBuilder->method('orderBy')->willReturnSelf();
+        $queryBuilder->method('addOrderBy')->willReturnSelf();
+        $queryBuilder->expects(self::once())
+            ->method('executeQuery')
+            ->willReturn($result);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::once())
+            ->method('createQueryBuilder')
+            ->willReturn($queryBuilder);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getConnection')->willReturn($connection);
+
+        $service = new TimeEntrySummaryService($entityManager);
+
+        $rows = $service->summarizeHoursByClientByWeek('2026-02-02', '2026-03-08');
+
+        self::assertSame([
+            [
+                'client_id' => 1,
+                'client_name' => 'Acme',
+                'week_key' => '2026-02-23',
+                'total_hours' => 18.75,
+            ],
+            [
+                'client_id' => 1,
+                'client_name' => 'Acme',
+                'week_key' => '2026-02-16',
+                'total_hours' => 12.25,
+            ],
+        ], $rows);
+    }
+
+    #[Test]
+    public function summarizeTotalHoursByWeekShouldUseSingleQueryBuilderQuery(): void
+    {
+        $result = $this->createMock(Result::class);
+        $result->expects(self::once())
+            ->method('fetchAllAssociative')
+            ->willReturn([
+                [
+                    'week_start' => '2026-02-23',
+                    'total_hours' => '30.50',
+                ],
+                [
+                    'week_start' => '2026-02-16',
+                    'total_hours' => '14.25',
+                ],
+            ]);
+
+        $queryBuilder = $this->createMock(DbalQueryBuilder::class);
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder->method('setParameter')->willReturnSelf();
+        $queryBuilder->method('groupBy')->willReturnSelf();
+        $queryBuilder->method('orderBy')->willReturnSelf();
+        $queryBuilder->expects(self::once())
+            ->method('executeQuery')
+            ->willReturn($result);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::once())
+            ->method('createQueryBuilder')
+            ->willReturn($queryBuilder);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getConnection')->willReturn($connection);
+
+        $service = new TimeEntrySummaryService($entityManager);
+
+        $rows = $service->summarizeTotalHoursByWeek('2026-02-02', '2026-03-08');
+
+        self::assertSame([
+            [
+                'week_key' => '2026-02-23',
+                'total_hours' => 30.5,
+            ],
+            [
+                'week_key' => '2026-02-16',
+                'total_hours' => 14.25,
+            ],
+        ], $rows);
+    }
+
+    #[Test]
     public function summarizeHoursByClientByDateShouldUseSingleQueryBuilderQuery(): void
     {
         $result = $this->createMock(Result::class);


### PR DESCRIPTION
## 概要

- ダッシュボードに「直近5週の稼働時間」サマリを追加
- 週単位の集計は月曜始まりで、クライアント別と合計を表示
- 週別集計用のサービスメソッドと単体テストを追加

Closes #75