### PR TITLE
Doctrine接続設定の重複を整理する

### DIFF
--- a/app/settings.php
+++ b/app/settings.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 use DI\ContainerBuilder;
 
-return function (ContainerBuilder $containerBuilder): void {
+$doctrineSettings = require __DIR__ . '/../config/doctrine.php';
+
+return function (ContainerBuilder $containerBuilder) use ($doctrineSettings): void {
     $containerBuilder->addDefinitions([
         'settings' => [
             'slim' => [
@@ -12,20 +14,7 @@ return function (ContainerBuilder $containerBuilder): void {
                 'logErrors' => true,
                 'logErrorDetails' => true,
             ],
-            'doctrine' => [
-                'dev_mode' => ($_ENV['APP_ENV'] ?? 'production') !== 'production',
-                'cache_dir' => __DIR__ . '/../var/doctrine',
-                'metadata_dirs' => [__DIR__ . '/../src/Domain/Entity'],
-                'connection' => [
-                    'driver' => 'pdo_mysql',
-                    'host' => $_ENV['DB_HOST'] ?? 'localhost',
-                    'port' => (int) ($_ENV['DB_PORT'] ?? 3306),
-                    'dbname' => $_ENV['DB_NAME'] ?? 'kizami',
-                    'user' => $_ENV['DB_USER'] ?? 'root',
-                    'password' => $_ENV['DB_PASSWORD'] ?? '',
-                    'charset' => 'utf8mb4',
-                ],
-            ],
+            'doctrine' => $doctrineSettings,
             'twig' => [
                 'template_path' => __DIR__ . '/../templates',
                 'cache_path' => ($_ENV['APP_ENV'] ?? 'production') === 'production'

--- a/bin/doctrine
+++ b/bin/doctrine
@@ -20,20 +20,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/..');
 $dotenv->safeLoad();
 
-$doctrineSettings = [
-    'dev_mode' => ($_ENV['APP_ENV'] ?? 'production') !== 'production',
-    'cache_dir' => __DIR__ . '/../var/doctrine',
-    'metadata_dirs' => [__DIR__ . '/../src/Domain/Entity'],
-    'connection' => [
-        'driver' => 'pdo_mysql',
-        'host' => $_ENV['DB_HOST'] ?? 'localhost',
-        'port' => (int) ($_ENV['DB_PORT'] ?? 3306),
-        'dbname' => $_ENV['DB_NAME'] ?? 'kizami',
-        'user' => $_ENV['DB_USER'] ?? 'kizami',
-        'password' => $_ENV['DB_PASSWORD'] ?? 'kizami',
-        'charset' => 'utf8mb4',
-    ],
-];
+$doctrineSettings = require __DIR__ . '/../config/doctrine.php';
 
 $cache = new ArrayAdapter();
 $config = ORMSetup::createAttributeMetadataConfiguration(

--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'dev_mode' => ($_ENV['APP_ENV'] ?? 'production') !== 'production',
+    'cache_dir' => __DIR__ . '/../var/doctrine',
+    'metadata_dirs' => [__DIR__ . '/../src/Domain/Entity'],
+    'connection' => [
+        'driver' => 'pdo_mysql',
+        'host' => $_ENV['DB_HOST'] ?? 'localhost',
+        'port' => (int) ($_ENV['DB_PORT'] ?? 3306),
+        'dbname' => $_ENV['DB_NAME'] ?? 'kizami',
+        'user' => $_ENV['DB_USER'] ?? 'root',
+        'password' => $_ENV['DB_PASSWORD'] ?? '',
+        'charset' => 'utf8mb4',
+    ],
+];


### PR DESCRIPTION
### 概要

- Issue #82 に対応し、アプリ本体と Doctrine CLI の接続設定を一元化します。
- DB 接続の既定値を単一の設定ファイルで管理できるようにします。

### 対応内容

- `config/doctrine.php` に Doctrine 設定を集約
- `app/settings.php` と `bin/doctrine` から共有設定を参照
- アプリ本体と CLI の DB ユーザー・パスワードの既定値を統一

### 検証

- PHPUnit: 39 tests / 107 assertions 成功
- PHP-CS-Fixer: 成功
- PHPStan: エラーなし（メモリ上限 512 MiB で実行）
- `git diff --check`: 成功

Closes #82